### PR TITLE
Add correlation id for tracing & refactoring

### DIFF
--- a/celery_amqp.go
+++ b/celery_amqp.go
@@ -266,7 +266,7 @@ func (*CeleryAMQPClient) prepareMessage(ctx context.Context, task string, args [
 	if params.CorrelationId != nil {
 		correlationId = *params.CorrelationId
 	} else {
-		correlationId = GetCtxValueString(ctx, correlationIdKey)
+		correlationId = GetCtxValueString(ctx, CorrelationIdKey)
 	}
 
 	headers := Headers{

--- a/celery_amqp.go
+++ b/celery_amqp.go
@@ -281,7 +281,7 @@ func (*CeleryAMQPClient) prepareMessage(ctx context.Context, task string, args [
 		ETA:                 params.Eta,
 		Expires:             expiry,
 		Retries:             Ptr(params.Retries),
-		TimeLimit:           Ptr(params.TimeLimit),
+		TimeLimit:           params.TimeLimit,
 		ArgsRepr:            string(argsBytes),
 		KWArgsRepr:          string(kwArgBytes),
 		Origin:              origin,

--- a/consts.go
+++ b/consts.go
@@ -14,7 +14,7 @@ const (
 	AMQP                    = "amqp"
 	baseSleepDuration       = 100 * time.Millisecond
 	defaultChannel          = "celery"
-	correlationIdKey        = "trace_id"
+	CorrelationIdKey        = "trace_id"
 )
 
 type LogLevel logrus.Level

--- a/consts.go
+++ b/consts.go
@@ -14,6 +14,7 @@ const (
 	AMQP                    = "amqp"
 	baseSleepDuration       = 100 * time.Millisecond
 	defaultChannel          = "celery"
+	correlationIdKey        = "trace_id"
 )
 
 type LogLevel logrus.Level

--- a/example/publisher/main.go
+++ b/example/publisher/main.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/Vipatra/celerygo"
 	"log"
 	"sync"
 	"time"
+
+	"github.com/Vipatra/celerygo"
+	"github.com/google/uuid"
 )
 
 var wg sync.WaitGroup
@@ -56,10 +58,12 @@ func worker(ctx context.Context, client celerygo.CeleryClient, wg *sync.WaitGrou
 		default:
 			time.Sleep(1000 * time.Millisecond)
 			log.Println("sending message")
+			traceId := uuid.New().String()
 			_, err := client.SendCeleryTask(context.Background(), "long_tasks.process_portfolio_jobs", nil, map[string]any{
 				"org_id": 798798,
 			}, &celerygo.AdditionalParameters{
 				CountdownSeconds: celerygo.Ptr(0),
+				CorrelationId:    &traceId,
 			})
 			if err != nil {
 				log.Println(fmt.Errorf("send task failed: %w", err))

--- a/misc.go
+++ b/misc.go
@@ -1,6 +1,7 @@
 package celerygo
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -37,4 +38,13 @@ func GetBodyTuple(body Body) ([]interface{}, error) {
 		return nil, err
 	}
 	return []interface{}{body.Args, body.Kwargs, embedMap}, nil
+}
+
+func GetCtxValueString(ctx context.Context, key string) string {
+	v := ctx.Value(key)
+	stringVal, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return stringVal
 }

--- a/models.go
+++ b/models.go
@@ -26,6 +26,8 @@ type Headers struct {
 	KWArgsRepr          string         `json:"kwargsrepr,"`
 	Origin              string         `json:"origin,"`
 	ReplacedTaskNesting *int           `json:"replaced_task_nesting,"`
+	// CorrelationId - Added as an additional field to trace the flow of request. By default, celery-go extracts from context value (trace_id). Capitalized to prevent clash with correlation_id of AMQP
+	CorrelationId string `json:"CORRELATION_ID"`
 }
 type Body struct {
 	Args   []interface{}          `json:"args"`
@@ -75,6 +77,8 @@ type AdditionalParameters struct {
 	ContentType         *string       `json:"content_type"`
 	ContentEncoding     *string       `json:"content_encoding"`
 	Language            *string       `json:"language"`
+	// CorrelationId - Added as an additional field to trace the flow of task. By default, celery-go extracts from context value (trace_id). Capitalized to prevent clash with correlation_id of AMQP
+	CorrelationId *string `json:"CORRELATION_ID"`
 }
 
 func (i *AdditionalParameters) GetContentType() string {

--- a/models.go
+++ b/models.go
@@ -26,7 +26,7 @@ type Headers struct {
 	KWArgsRepr          string         `json:"kwargsrepr,"`
 	Origin              string         `json:"origin,"`
 	ReplacedTaskNesting *int           `json:"replaced_task_nesting,"`
-	// CorrelationId - Added as an additional field to trace the flow of request. By default, celery-go extracts from context value (trace_id). Capitalized to prevent clash with correlation_id of AMQP
+	// CorrelationId - Added as an additional field to trace the flow of request. By default, celery-go extracts from context value (CorrelationIdKey). Capitalized to prevent clash with correlation_id of AMQP
 	CorrelationId string `json:"CORRELATION_ID"`
 }
 type Body struct {
@@ -77,7 +77,7 @@ type AdditionalParameters struct {
 	ContentType         *string       `json:"content_type"`
 	ContentEncoding     *string       `json:"content_encoding"`
 	Language            *string       `json:"language"`
-	// CorrelationId - Added as an additional field to trace the flow of task. By default, celery-go extracts from context value (trace_id). Capitalized to prevent clash with correlation_id of AMQP
+	// CorrelationId - Added as an additional field to trace the flow of task. By default, celery-go extracts from context value (CorrelationIdKey). Capitalized to prevent clash with correlation_id of AMQP
 	CorrelationId *string `json:"CORRELATION_ID"`
 }
 

--- a/models.go
+++ b/models.go
@@ -10,22 +10,22 @@ type Message struct {
 }
 
 type Headers struct {
-	Lang                string         `json:"lang"`
-	Task                string         `json:"task"`
-	ID                  string         `json:"id"`
-	RootID              string         `json:"root_id"`
-	ParentID            *string        `json:"parent_id"`
-	Group               *string        `json:"group"`
-	Method              *string        `json:"meth,"`
-	Shadow              *string        `json:"shadow,"`
-	ETA                 *string        `json:"eta,"`
-	Expires             *string        `json:"expires,"`
-	Retries             *int           `json:"retries,"`
-	TimeLimit           *[]interface{} `json:"timelimit,"`
-	ArgsRepr            string         `json:"argsrepr,"`
-	KWArgsRepr          string         `json:"kwargsrepr,"`
-	Origin              string         `json:"origin,"`
-	ReplacedTaskNesting *int           `json:"replaced_task_nesting,"`
+	Lang                string        `json:"lang"`
+	Task                string        `json:"task"`
+	ID                  string        `json:"id"`
+	RootID              string        `json:"root_id"`
+	ParentID            *string       `json:"parent_id"`
+	Group               *string       `json:"group"`
+	Method              *string       `json:"meth,"`
+	Shadow              *string       `json:"shadow,"`
+	ETA                 *string       `json:"eta,"`
+	Expires             *string       `json:"expires,"`
+	Retries             *int          `json:"retries,"`
+	TimeLimit           []interface{} `json:"timelimit,"`
+	ArgsRepr            string        `json:"argsrepr,"`
+	KWArgsRepr          string        `json:"kwargsrepr,"`
+	Origin              string        `json:"origin,"`
+	ReplacedTaskNesting *int          `json:"replaced_task_nesting,"`
 	// CorrelationId - Added as an additional field to trace the flow of request. By default, celery-go extracts from context value (CorrelationIdKey). Capitalized to prevent clash with correlation_id of AMQP
 	CorrelationId string `json:"CORRELATION_ID"`
 }


### PR DESCRIPTION
- Add option to pass traceId or any id as `CORRELATION_ID` to keep track of flow of task / event
- Remove unnecessary pointer for `timelimit` slice